### PR TITLE
fix: shutdown workers gracefully by closing the done channel

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -61,6 +61,7 @@ func (s *Service[IN, OUT]) Run() error {
 	}
 
 	<-signals
+	close(s.done)
 	s.Debug("graceful shutdown")
 	s.wg.Wait()
 	s.broker.Exit()


### PR DESCRIPTION
closing `done` channel allows to close `waitgroup` and stop all workers. without it `s.wg.Done()` never happens